### PR TITLE
Parse event delim across chunks

### DIFF
--- a/sseclient/__init__.py
+++ b/sseclient/__init__.py
@@ -15,6 +15,7 @@ __copyright__ = 'Copyright (C) 2016-2017 SignalFx, Inc. All rights reserved.'
 __all__ = ['SSEClient']
 
 _FIELD_SEPARATOR = ':'
+_MAX_EVENT_DELIM_LEN = 4
 
 
 class SSEClient(object):
@@ -45,12 +46,16 @@ class SSEClient(object):
         to correctly stitch together consecutive response chunks and find the
         SSE delimiter (empty new line) to yield full, correct event chunks."""
         data = b''
+        cursor = 0
         for chunk in self._event_source:
-            for line in chunk.splitlines(True):
-                if not line.strip():
-                    yield data
-                    data = b''
-                data += line
+            data += chunk
+            delim = max(map(lambda s: (data.find(s, cursor), len(s)), ('\r\n\r\n', '\r\r', '\n\n')))
+            if delim[0] != -1:
+                yield data[:delim[0]]
+                data = data[delim[0] + delim[1]:]
+                cursor = 0
+            else:
+                cursor += len(chunk) - _MAX_EVENT_DELIM_LEN
         if data:
             yield data
 


### PR DESCRIPTION
This fixes issue #11, where it's possible that `chunk.splitlines()` would split in such a way that there is an empty line in the chunk which isn't actually an empty line in the data stream. For example:
```
event: test event
data: {
data:     "terribly_split": "json_objects in SSE",
data:     "which_should_probably": "be on a single line",
data:     "but_oh_well": 1
data: }

```
It's possible for this to be split into the following chunks (new line characters added for emphasis)
```
event: test event\r\n
data: {\r\n
data:    "terribly_split": "json_objects in SSE",
```
And
```
\r\n
data:     "which_should_probably": "be on a single line",\r\n
data:     "but_oh_well": 1\r\n
data: }\r\n
\r\n
```
The current `chunk.splitlines()` would separate yield the first block as a valid SSE event when it parses the second block, as the first "line" would be empty even though technically it's a continuation of the above line in the chunk.

This change instead looks for event delimiters by seeking double-newline sub strings (`\r\n\r\n`, `\r\r`, `\n\n`) across chunks as they arrive, trailing by the max length of a delimiter substring (to make sure we don't miss delimiters across chunks). 

It's probably not the best solution but at least it illustrates the problem.