### PR TITLE
Declare support for Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ setup(
     classifiers=[
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
     ],
     url='https://github.com/mpetazzoni/sseclient',
 )

--- a/sseclient/version.py
+++ b/sseclient/version.py
@@ -1,2 +1,2 @@
 name = 'sseclient-py'
-version = '1.7'
+version = '1.7.1'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, flake8
+envlist = py27, py35, py37, flake8
 skip_missing_interpreters = true
 
 [testenv]
@@ -12,4 +12,8 @@ deps = flake8
 
 [testenv:py35]
 basepython = python3.5
+install_command = pip3 install {opts} {packages}
+
+[testenv:py37]
+basepython = python3.7
 install_command = pip3 install {opts} {packages}


### PR DESCRIPTION
Tests pass on Python 3.7 as well, so we can declare that this module supports both 3.5 and 3.7 in addition to 2.7.